### PR TITLE
9 three state form to top setting

### DIFF
--- a/.github/workflows/b2s-backglass.yml
+++ b/.github/workflows/b2s-backglass.yml
@@ -151,6 +151,7 @@ jobs:
          path: tmp
 
   build-betterled:
+    if: ${{ false }}  # disable for now
     name: Build BetterLed-${{ matrix.config }}-win-${{ matrix.platform }}
     runs-on: windows-2019
     strategy:

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+1.3.1.2
+
+- Add additional setting FormToBack complementing FormToFront. The "Standard" setting (both FormToBack and FormToFront turned off) is now as it was in 1.3.0.6. -> formDMD isn't controlled by the FormToFront/Back setting
+- Merge some more settings in the dll version.
+- Make sure LED "D" (Digit) updates from VPMame is forwarded to all plugins. thanks to rdowens11vx!
+
 1.3.1.1
 
 - Its now possible to use a different filename than ScreenRes.txt via the registry-key "Software\B2S\B2SScreenResFileNameOverride"

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,9 @@
 1.3.1.2
 
-- Add additional setting FormToBack complementing FormToFront. The "Standard" setting (both FormToBack and FormToFront turned off) is now as it was in 1.3.0.6. -> formDMD isn't controlled by the FormToFront/Back setting
+- Add additional setting FormToBack complementing FormToFront. Now three states available:
+  1. "Standard" setting (both FormToBack and FormToFront turned off) is now as it was in 1.3.0.6. -> formDMD isn't controlled by the FormToFront/Back setting
+  2. FormToFront sets the flag Form.TopMost = True -> cannot get any other window on top
+  3. FormToBack, forces the forms back and ignores any try to get them come forward -> Windows stay in back. The B2S Server is not available in the taskbar anymore.
 - Merge some more settings in the dll version.
 - Make sure LED "D" (Digit) updates from VPMame is forwarded to all plugins. thanks to rdowens11vx!
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 ## Installation:
 
-- Unzip all files into your VP tables folder and overwrite already existing files with this new ones.
+- Unzip all files into a folder under your VP folder and overwrite already existing files with this new ones.
+  **It doesn't have to be installed in the tables folder! An example would be C:\vPinball\VisualPinball\B2SServer.**
 - Right click the `B2SBackglassServer.dll` and click on `Properties`. Maybe you'll find the following text on the `General` tab:
   `This file came from another computer and might be blocked to help protect this computer`. Click on the `Unblock` button.
   Everything is fine when you are not able to find this text.
 - Start the `B2SBackglassServerRegisterApp.exe` in the VP tables folder and the server dll should be registered.
-  **IMPORTANT**: With Win7 (and above) start the .exe as administrator.
+  **IMPORTANT**: With Win7 (and above) start the .exe as administrator. Old installations can be cleaned up using [Nirsoft's RegDllView](https://www.nirsoft.net/utils/registered_dll_view.html)
 - On older windows machines, check the color depth of the backglass monitor. It has to be 32bit.
 - Also on older windows versions, the B2S backglass server requires .NET Framework 4 to be installed on your computer. It can be downloaded [here](http://www.microsoft.com/downloads/en/details.aspx?FamilyID=0a391abd-25c1-4fc0-919f-b21f31ab88b7&displaylang=en).
 

--- a/b2s_screenresidentifier/b2s_screenresidentifier/My Project/AssemblyInfo.vb
+++ b/b2s_screenresidentifier/b2s_screenresidentifier/My Project/AssemblyInfo.vb
@@ -31,6 +31,6 @@ Imports System.Runtime.InteropServices
 ' übernehmen, indem Sie "*" eingeben:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.3.1.1")> 
-<Assembly: AssemblyFileVersion("1.3.1.1")> 
-<Assembly: AssemblyInformationalVersion("1.3.1.1")>
+<Assembly: AssemblyVersion("1.3.1.2")> 
+<Assembly: AssemblyFileVersion("1.3.1.2")> 
+<Assembly: AssemblyInformationalVersion("1.3.1.2")>

--- a/b2sbackglassserver/b2sbackglassserver/Classes/B2SScreen.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Classes/B2SScreen.vb
@@ -331,10 +331,11 @@ Public Class B2SScreen
         Me.formBackglass.MinimizeBox = False
         Me.formBackglass.Location = screen.Bounds.Location + Me.BackglassLocation
         Me.formBackglass.Size = Me.BackglassSize
-        Me.formBackglass.Text = "Form1"
+        Me.formBackglass.Text = "B2S Backglass Server"
         Me.formBackglass.Show()
         
         ' bring backglass screen to the front
+        If B2SSettings.FormToFront Then Me.formBackglass.TopMost = True
         Me.formBackglass.BringToFront()
 
         ' maybe show DMD form
@@ -348,8 +349,9 @@ Public Class B2SScreen
             Me.formDMD.MinimizeBox = False
             Me.formDMD.Location = Me.formBackglass.Location + Me.DMDLocation
             Me.formDMD.Size = Me.DMDSize
+            Me.formDMD.Text = "B2S DMD"
             ' show the DMD form
-            Me.formDMD.Show() 'formBackglass)
+            Me.formDMD.Show()
             Me.formDMD.BringToFront()
             Me.formDMD.TopMost = True
         End If

--- a/b2sbackglassserver/b2sbackglassserver/Classes/B2SSettings.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Classes/B2SSettings.vb
@@ -3,7 +3,7 @@ Imports System.IO
 
 Public Class B2SSettings
 
-    Public Const DirectB2SVersion As String = "1.3.1.1"
+    Public Const DirectB2SVersion As String = "1.3.1.2"
     Public Const MinimumDirectB2SVersion As String = "1.0"
     Public Shared Property BackglassFileVersion() As String = String.Empty
 
@@ -154,7 +154,7 @@ Public Class B2SSettings
     Public Shared Property GlowIndex() As Integer = -1
     Public Shared Property DefaultGlow() As Integer = -1
     Public Shared Property FormToFront() As Boolean = True
-
+    Public Shared Property FormToBack() As Boolean = False
     Public Shared Property HideGrill() As System.Windows.Forms.CheckState = Windows.Forms.CheckState.Indeterminate
     Public Shared Property HideB2SDMD() As Boolean = False
     Public Shared Property HideDMD() As System.Windows.Forms.CheckState = Windows.Forms.CheckState.Indeterminate
@@ -239,7 +239,11 @@ Public Class B2SSettings
                             StartBackground = GlobalStartBackground
                         End If
 
-                If nodeHeader.SelectSingleNode("FormToFront") IsNot Nothing Then FormToFront = (nodeHeader.SelectSingleNode("FormToFront").InnerText = "1")
+                        If nodeHeader.SelectSingleNode("FormToFront") IsNot Nothing Then FormToFront = (nodeHeader.SelectSingleNode("FormToFront").InnerText = "1")
+                        If nodeHeader.SelectSingleNode("FormToBack") IsNot Nothing Then
+                            FormToBack = (nodeHeader.SelectSingleNode("FormToBack").InnerText = "1")
+                            If FormToBack Then FormToFront = False
+                        End If
                         If nodeHeader.SelectSingleNode("ScreenshotPath") IsNot Nothing Then
                             ScreenshotPath = nodeHeader.SelectSingleNode("ScreenshotPath").InnerText
                             ScreenshotFileType = CInt(nodeHeader.SelectSingleNode("ScreenshotFileType").InnerText)
@@ -281,8 +285,12 @@ Public Class B2SSettings
                                 If nodeTable.SelectSingleNode("GlowIndex") IsNot Nothing Then GlowIndex = CInt(nodeTable.SelectSingleNode("GlowIndex").InnerText)
                                 If nodeTable.SelectSingleNode("StartAsEXE") IsNot Nothing Then StartAsEXE = (nodeTable.SelectSingleNode("StartAsEXE").InnerText = "1")
                                 If nodeTable.SelectSingleNode("DualMode") IsNot Nothing Then CurrentDualMode = CInt(nodeTable.SelectSingleNode("DualMode").InnerText)
-                        If nodeTable.SelectSingleNode("StartBackground") IsNot Nothing Then StartBackground = (nodeTable.SelectSingleNode("StartBackground").InnerText = "1")
-                        If nodeTable.SelectSingleNode("FormToFront") IsNot Nothing Then FormToFront = (nodeTable.SelectSingleNode("FormToFront").InnerText = "1")
+                                If nodeTable.SelectSingleNode("StartBackground") IsNot Nothing Then StartBackground = (nodeTable.SelectSingleNode("StartBackground").InnerText = "1")
+                                If nodeTable.SelectSingleNode("FormToFront") IsNot Nothing Then FormToFront = (nodeTable.SelectSingleNode("FormToFront").InnerText = "1")
+                                If nodeTable.SelectSingleNode("FormToBack") IsNot Nothing Then
+                                    FormToBack = (nodeTable.SelectSingleNode("FormToBack").InnerText = "1")
+                                    If FormToBack Then FormToFront = False
+                                End If
 
                                 Dim nodeAnimations As Xml.XmlElement = nodeTable.SelectSingleNode("Animations")
                                 If nodeAnimations IsNot Nothing Then
@@ -358,10 +366,11 @@ Public Class B2SSettings
 
                 ' Only save the StartBackground setting on table level if different from GlobalStartBackground or non existent
                 If (Not GlobalStartBackground.HasValue) Or (GlobalStartBackground Xor StartBackground) Then
-                AddNode(XML, nodeTable, "StartBackground", If(StartBackground, "1", "0"))
+                    AddNode(XML, nodeTable, "StartBackground", If(StartBackground, "1", "0"))
                 End If
 
                 AddNode(XML, nodeTable, "FormToFront", If(FormToFront, "1", "0"))
+                AddNode(XML, nodeTable, "FormToBack", If(FormToBack, "1", "0"))
 
                 If b2sanimation IsNot Nothing Then
                     Dim nodeAnimations As Xml.XmlElement = AddHeader(XML, nodeTable, "Animations")
@@ -422,6 +431,8 @@ Public Class B2SSettings
         AnimationSlowDowns.Clear()
         AllAnimationSlowDown = 1
         CurrentDualMode = eDualMode.NotSet
+        FormToFront = True
+        FormToBack = False
     End Sub
 
     Private Shared Function AddHeader(XML As Xml.XmlDocument, parentnode As Xml.XmlNode, nodename As String) As Xml.XmlNode

--- a/b2sbackglassserver/b2sbackglassserver/Forms/formSettings.Designer.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Forms/formSettings.Designer.vb
@@ -31,6 +31,8 @@ Partial Class formSettings
         Me.chkActivatePlugins = New System.Windows.Forms.CheckBox()
         Me.btnPluginSettings = New System.Windows.Forms.Button()
         Me.grpStartMode = New System.Windows.Forms.GroupBox()
+        Me.lblFormFront = New System.Windows.Forms.Label()
+        Me.cmbFormFront = New System.Windows.Forms.ComboBox()
         Me.lblDefaultStartMode = New System.Windows.Forms.Label()
         Me.chkStartAsEXE = New System.Windows.Forms.CheckBox()
         Me.cmbDefaultStartMode = New System.Windows.Forms.ComboBox()
@@ -47,7 +49,7 @@ Partial Class formSettings
         Me.cmbAnimations = New System.Windows.Forms.ComboBox()
         Me.lblVersion = New System.Windows.Forms.Label()
         Me.grpScreenshot = New System.Windows.Forms.GroupBox()
-        Me.Label1 = New System.Windows.Forms.Label()
+        Me.lblFileType = New System.Windows.Forms.Label()
         Me.cmbScreenshotType = New System.Windows.Forms.ComboBox()
         Me.btnScreenshotPath = New System.Windows.Forms.Button()
         Me.btnCloseSettings = New System.Windows.Forms.Button()
@@ -117,7 +119,7 @@ Partial Class formSettings
         Me.PanelSettings.Dock = System.Windows.Forms.DockStyle.Fill
         Me.PanelSettings.Location = New System.Drawing.Point(0, 0)
         Me.PanelSettings.Name = "PanelSettings"
-        Me.PanelSettings.Size = New System.Drawing.Size(504, 572)
+        Me.PanelSettings.Size = New System.Drawing.Size(491, 593)
         Me.PanelSettings.TabIndex = 2
         '
         'grpPlugins
@@ -125,7 +127,7 @@ Partial Class formSettings
         Me.grpPlugins.Controls.Add(Me.chkShowStartupError)
         Me.grpPlugins.Controls.Add(Me.chkActivatePlugins)
         Me.grpPlugins.Controls.Add(Me.btnPluginSettings)
-        Me.grpPlugins.Location = New System.Drawing.Point(15, 479)
+        Me.grpPlugins.Location = New System.Drawing.Point(15, 501)
         Me.grpPlugins.Name = "grpPlugins"
         Me.grpPlugins.Size = New System.Drawing.Size(475, 50)
         Me.grpPlugins.TabIndex = 36
@@ -164,15 +166,36 @@ Partial Class formSettings
         '
         'grpStartMode
         '
+        Me.grpStartMode.Controls.Add(Me.lblFormFront)
+        Me.grpStartMode.Controls.Add(Me.cmbFormFront)
         Me.grpStartMode.Controls.Add(Me.lblDefaultStartMode)
         Me.grpStartMode.Controls.Add(Me.chkStartAsEXE)
         Me.grpStartMode.Controls.Add(Me.cmbDefaultStartMode)
-        Me.grpStartMode.Location = New System.Drawing.Point(15, 161)
+        Me.grpStartMode.Location = New System.Drawing.Point(15, 160)
         Me.grpStartMode.Name = "grpStartMode"
-        Me.grpStartMode.Size = New System.Drawing.Size(474, 48)
+        Me.grpStartMode.Size = New System.Drawing.Size(474, 75)
         Me.grpStartMode.TabIndex = 2
         Me.grpStartMode.TabStop = False
         Me.grpStartMode.Text = "Backglass start mode"
+        '
+        'lblFormFront
+        '
+        Me.lblFormFront.AutoSize = True
+        Me.lblFormFront.Location = New System.Drawing.Point(50, 49)
+        Me.lblFormFront.Name = "lblFormFront"
+        Me.lblFormFront.Size = New System.Drawing.Size(47, 13)
+        Me.lblFormFront.TabIndex = 41
+        Me.lblFormFront.Text = "Bring BG"
+        '
+        'cmbFormFront
+        '
+        Me.cmbFormFront.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.cmbFormFront.FormattingEnabled = True
+        Me.cmbFormFront.Items.AddRange(New Object() {"Form to Back", "Standard", "Form to Top"})
+        Me.cmbFormFront.Location = New System.Drawing.Point(103, 46)
+        Me.cmbFormFront.Name = "cmbFormFront"
+        Me.cmbFormFront.Size = New System.Drawing.Size(127, 21)
+        Me.cmbFormFront.TabIndex = 27
         '
         'lblDefaultStartMode
         '
@@ -207,7 +230,7 @@ Partial Class formSettings
         'btnMore
         '
         Me.btnMore.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.btnMore.Location = New System.Drawing.Point(15, 541)
+        Me.btnMore.Location = New System.Drawing.Point(15, 562)
         Me.btnMore.Name = "btnMore"
         Me.btnMore.Size = New System.Drawing.Size(73, 24)
         Me.btnMore.TabIndex = 32
@@ -293,7 +316,7 @@ Partial Class formSettings
         '
         Me.grpAnimationSettings.Controls.Add(Me.cmbAnimationSetting)
         Me.grpAnimationSettings.Controls.Add(Me.cmbAnimations)
-        Me.grpAnimationSettings.Location = New System.Drawing.Point(15, 371)
+        Me.grpAnimationSettings.Location = New System.Drawing.Point(15, 391)
         Me.grpAnimationSettings.Name = "grpAnimationSettings"
         Me.grpAnimationSettings.Size = New System.Drawing.Size(474, 51)
         Me.grpAnimationSettings.TabIndex = 5
@@ -326,30 +349,30 @@ Partial Class formSettings
         Me.lblVersion.Location = New System.Drawing.Point(54, 30)
         Me.lblVersion.Name = "lblVersion"
         Me.lblVersion.Size = New System.Drawing.Size(265, 13)
-        Me.lblVersion.TabIndex = 27
+        Me.lblVersion.TabIndex = 37
         Me.lblVersion.Text = "Server version {0}, Backglass file version {1}"
         '
         'grpScreenshot
         '
-        Me.grpScreenshot.Controls.Add(Me.Label1)
+        Me.grpScreenshot.Controls.Add(Me.lblFileType)
         Me.grpScreenshot.Controls.Add(Me.cmbScreenshotType)
         Me.grpScreenshot.Controls.Add(Me.btnScreenshotPath)
-        Me.grpScreenshot.Location = New System.Drawing.Point(15, 425)
+        Me.grpScreenshot.Location = New System.Drawing.Point(15, 447)
         Me.grpScreenshot.Name = "grpScreenshot"
         Me.grpScreenshot.Size = New System.Drawing.Size(475, 50)
         Me.grpScreenshot.TabIndex = 6
         Me.grpScreenshot.TabStop = False
         Me.grpScreenshot.Text = "Screenshot"
         '
-        'Label1
+        'lblFileType
         '
-        Me.Label1.AutoSize = True
-        Me.Label1.Location = New System.Drawing.Point(268, 21)
-        Me.Label1.Name = "Label1"
-        Me.Label1.Size = New System.Drawing.Size(83, 13)
-        Me.Label1.TabIndex = 27
-        Me.Label1.Text = "Image file type:"
-        Me.Label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight
+        Me.lblFileType.AutoSize = True
+        Me.lblFileType.Location = New System.Drawing.Point(268, 19)
+        Me.lblFileType.Name = "lblFileType"
+        Me.lblFileType.Size = New System.Drawing.Size(83, 13)
+        Me.lblFileType.TabIndex = 0
+        Me.lblFileType.Text = "Image file type:"
+        Me.lblFileType.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         '
         'cmbScreenshotType
         '
@@ -375,7 +398,7 @@ Partial Class formSettings
         Me.btnCloseSettings.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.btnCloseSettings.DialogResult = System.Windows.Forms.DialogResult.Cancel
         Me.btnCloseSettings.Font = New System.Drawing.Font("Tahoma", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.btnCloseSettings.Location = New System.Drawing.Point(414, 541)
+        Me.btnCloseSettings.Location = New System.Drawing.Point(401, 562)
         Me.btnCloseSettings.Name = "btnCloseSettings"
         Me.btnCloseSettings.Size = New System.Drawing.Size(78, 24)
         Me.btnCloseSettings.TabIndex = 35
@@ -479,9 +502,9 @@ Partial Class formSettings
         Me.btnSaveSettings.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.btnSaveSettings.Font = New System.Drawing.Font("Tahoma", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.btnSaveSettings.Location = New System.Drawing.Point(96, 541)
+        Me.btnSaveSettings.Location = New System.Drawing.Point(96, 562)
         Me.btnSaveSettings.Name = "btnSaveSettings"
-        Me.btnSaveSettings.Size = New System.Drawing.Size(311, 24)
+        Me.btnSaveSettings.Size = New System.Drawing.Size(298, 24)
         Me.btnSaveSettings.TabIndex = 34
         Me.btnSaveSettings.Text = "Save settings"
         Me.btnSaveSettings.UseVisualStyleBackColor = True
@@ -494,7 +517,7 @@ Partial Class formSettings
         Me.grpLEDs.Controls.Add(Me.radioDream7LED)
         Me.grpLEDs.Controls.Add(Me.chkWireframe)
         Me.grpLEDs.Controls.Add(Me.chkBulbs)
-        Me.grpLEDs.Location = New System.Drawing.Point(15, 288)
+        Me.grpLEDs.Location = New System.Drawing.Point(15, 306)
         Me.grpLEDs.Name = "grpLEDs"
         Me.grpLEDs.Size = New System.Drawing.Size(474, 80)
         Me.grpLEDs.TabIndex = 4
@@ -576,7 +599,7 @@ Partial Class formSettings
         Me.grpPerfTuning.Controls.Add(Me.lblSolenoidBlackTurns)
         Me.grpPerfTuning.Controls.Add(Me.numGISkipFrames)
         Me.grpPerfTuning.Controls.Add(Me.lblGIBlackTurns)
-        Me.grpPerfTuning.Location = New System.Drawing.Point(15, 211)
+        Me.grpPerfTuning.Location = New System.Drawing.Point(15, 233)
         Me.grpPerfTuning.Name = "grpPerfTuning"
         Me.grpPerfTuning.Size = New System.Drawing.Size(474, 75)
         Me.grpPerfTuning.TabIndex = 3
@@ -655,7 +678,7 @@ Partial Class formSettings
         '
         Me.btnDonate.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.btnDonate.Image = CType(resources.GetObject("btnDonate.Image"), System.Drawing.Image)
-        Me.btnDonate.Location = New System.Drawing.Point(57, 49)
+        Me.btnDonate.Location = New System.Drawing.Point(44, 49)
         Me.btnDonate.Name = "btnDonate"
         Me.btnDonate.Size = New System.Drawing.Size(435, 31)
         Me.btnDonate.TabIndex = 35
@@ -668,7 +691,7 @@ Partial Class formSettings
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(504, 572)
+        Me.ClientSize = New System.Drawing.Size(491, 593)
         Me.Controls.Add(Me.PanelSettings)
         Me.Font = New System.Drawing.Font("Tahoma", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
@@ -710,7 +733,7 @@ Partial Class formSettings
     Friend WithEvents cmbAnimations As System.Windows.Forms.ComboBox
     Friend WithEvents lblVersion As System.Windows.Forms.Label
     Friend WithEvents grpScreenshot As System.Windows.Forms.GroupBox
-    Friend WithEvents Label1 As System.Windows.Forms.Label
+    Friend WithEvents lblFileType As System.Windows.Forms.Label
     Friend WithEvents cmbScreenshotType As System.Windows.Forms.ComboBox
     Friend WithEvents btnScreenshotPath As System.Windows.Forms.Button
     Friend WithEvents btnCloseSettings As System.Windows.Forms.Button
@@ -754,7 +777,9 @@ Partial Class formSettings
     Friend WithEvents grpStartMode As System.Windows.Forms.GroupBox
     Friend WithEvents btnDonate As System.Windows.Forms.Button
     Friend WithEvents grpPlugins As System.Windows.Forms.GroupBox
+    Friend WithEvents chkShowStartupError As System.Windows.Forms.CheckBox
     Friend WithEvents chkActivatePlugins As System.Windows.Forms.CheckBox
     Friend WithEvents btnPluginSettings As System.Windows.Forms.Button
-    Friend WithEvents chkShowStartupError As System.Windows.Forms.CheckBox
+    Friend WithEvents lblFormFront As System.Windows.Forms.Label
+    Friend WithEvents cmbFormFront As System.Windows.Forms.ComboBox
 End Class

--- a/b2sbackglassserver/b2sbackglassserver/Forms/formSettings.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Forms/formSettings.vb
@@ -82,6 +82,8 @@ Public Class formSettings
             radioDream7LED.Enabled = False
         End If
         chkBulbs.Checked = B2SSettings.IsGlowBulbOn
+        cmbFormFront.SelectedIndex = If(B2SSettings.FormToBack, 0, If(B2SSettings.FormToFront, 2, 1))
+
         cmbGlowing.SelectedIndex = If(B2SSettings.GlowIndex <> -1, B2SSettings.GlowIndex, cmbGlowing.Items.Count - 1)
         activateMsgBoxAtSaving = False
         ' get animation info
@@ -438,4 +440,14 @@ Public Class formSettings
         Return ret
     End Function
 
+    Private Sub cmbFormFront_SelectedIndexChanged(sender As Object, e As EventArgs) Handles cmbFormFront.SelectedIndexChanged
+        B2SSettings.FormToBack = False
+        B2SSettings.FormToFront = False
+
+        If cmbFormFront.SelectedIndex = 0 Then
+            B2SSettings.FormToBack = True
+        ElseIf cmbFormFront.SelectedIndex = 2 Then
+            B2SSettings.FormToFront = True
+        End If
+    End Sub
 End Class

--- a/b2sbackglassserver/b2sbackglassserver/My Project/AssemblyInfo.vb
+++ b/b2sbackglassserver/b2sbackglassserver/My Project/AssemblyInfo.vb
@@ -31,6 +31,6 @@ Imports System.Runtime.InteropServices
 ' übernehmen, indem Sie "*" eingeben:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.3.1.1")> 
-<Assembly: AssemblyFileVersion("1.3.1.1")> 
-<Assembly: AssemblyInformationalVersion("1.3.1.1")> 
+<Assembly: AssemblyVersion("1.3.1.2")> 
+<Assembly: AssemblyFileVersion("1.3.1.2")> 
+<Assembly: AssemblyInformationalVersion("1.3.1.2")> 

--- a/b2sbackglassserver/b2sbackglassserver/moduleImageExtensions.vb
+++ b/b2sbackglassserver/b2sbackglassserver/moduleImageExtensions.vb
@@ -56,13 +56,4 @@ Module moduleImageExtensions
         Return ret
     End Function
 
-    '<System.Runtime.CompilerServices.Extension()> _
-    'Public Function PartFromImage(image As Image, area As Rectangle) As Image
-    '    If image Is Nothing Then Return Nothing
-    '    Dim imageBackground As Bitmap = CType(image, Bitmap)
-    '    Dim imagePart As Image = New Bitmap(area.Width, area.Height)
-    '    imagePart = imageBackground.Clone(area, Imaging.PixelFormat.Format32bppArgb)
-    '    Return imagePart
-    'End Function
-
 End Module

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Classes/B2SScreen.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Classes/B2SScreen.vb
@@ -325,6 +325,7 @@ Public Class B2SScreen
             Me.formbackground.Show()
             If B2SSettings.FormToBack Then
                 Me.formbackground.SendToBack()
+                Me.formbackground.ShowInTaskbar = False
             Else
                 Me.formbackground.BringToFront()
             End If
@@ -391,8 +392,15 @@ Public Class B2SScreen
             Me.formBackglass.Show()
         End If
         ' bring backglass screen to the front
-        If B2SSettings.FormToFront Then Me.formBackglass.TopMost = True
-        Me.formBackglass.BringToFront()
+        If B2SSettings.FormToFront Then
+            Me.formBackglass.TopMost = True
+            Me.formBackglass.BringToFront()
+        ElseIf B2SSettings.FormToBack Then
+            Me.formBackglass.SendToBack()
+            Me.formBackglass.ShowInTaskbar = False
+        Else
+            Me.formBackglass.BringToFront()
+        End If
 
         ' maybe show DMD form
         If IsDMDToBeShown Then
@@ -406,11 +414,15 @@ Public Class B2SScreen
             Me.formDMD.Location = Me.BackglassScreen.Bounds.Location + OriginalOffset + Me.DMDLocation  ' was Me.formBackglass.Location + Me.DMDLocation
             Me.formDMD.Size = Me.DMDSize
             Me.formDMD.Text = "B2S DMD"
-            'Me.formDMD.ShowInTaskbar = False
-            'Me.formDMD.Show(Me.formBackglass)
-            Me.formDMD.Show()
-            Me.formDMD.BringToFront()
-            Me.formDMD.TopMost = True
+
+            If B2SSettings.FormToBack Then
+                Me.formDMD.ShowInTaskbar = False
+                Me.formDMD.Show(Me.formBackglass)
+            Else
+                Me.formDMD.Show()
+                Me.formDMD.BringToFront()
+                Me.formDMD.TopMost = True
+            End If
         End If
 
     End Sub

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Classes/B2SScreen.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Classes/B2SScreen.vb
@@ -323,10 +323,10 @@ Public Class B2SScreen
                 Me.formbackground.BackgroundImage = Image.FromFile(Me.BackgroundPath) ' ("C:\backglass.png")
             End If
             Me.formbackground.Show()
-            If B2SSettings.FormToFront Then
-                Me.formbackground.BringToFront()
-            Else
+            If B2SSettings.FormToBack Then
                 Me.formbackground.SendToBack()
+            Else
+                Me.formbackground.BringToFront()
             End If
         End If
 
@@ -406,11 +406,11 @@ Public Class B2SScreen
             Me.formDMD.Location = Me.BackglassScreen.Bounds.Location + OriginalOffset + Me.DMDLocation  ' was Me.formBackglass.Location + Me.DMDLocation
             Me.formDMD.Size = Me.DMDSize
             Me.formDMD.Text = "B2S DMD"
-            Me.formDMD.ShowInTaskbar = False
-            Me.formDMD.Show(Me.formBackglass)
-            If B2SSettings.FormToFront Then Me.formDMD.TopMost = True
+            'Me.formDMD.ShowInTaskbar = False
+            'Me.formDMD.Show(Me.formBackglass)
+            Me.formDMD.Show()
             Me.formDMD.BringToFront()
-
+            Me.formDMD.TopMost = True
         End If
 
     End Sub

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Classes/B2SSettings.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Classes/B2SSettings.vb
@@ -3,7 +3,7 @@ Imports System.IO
 
 Public Class B2SSettings
 
-    Public Const DirectB2SVersion As String = "1.3.1.1"
+    Public Const DirectB2SVersion As String = "1.3.1.2"
     Public Const MinimumDirectB2SVersion As String = "1.0"
     Public Shared Property BackglassFileVersion() As String = String.Empty
 
@@ -81,7 +81,7 @@ Public Class B2SSettings
     Public Shared Property GlowIndex() As Integer = -1
     Public Shared Property DefaultGlow() As Integer = -1
     Public Shared Property FormToFront() As Boolean = True
-
+    Public Shared Property FormToBack() As Boolean = False
     Public Shared Property HideGrill() As System.Windows.Forms.CheckState = Windows.Forms.CheckState.Indeterminate
     Public Shared Property HideB2SDMD() As Boolean = False
     Public Shared Property HideDMD() As System.Windows.Forms.CheckState = Windows.Forms.CheckState.Indeterminate
@@ -164,6 +164,10 @@ Public Class B2SSettings
                     StartBackground = GlobalStartBackground
                 End If
                 If nodeHeader.SelectSingleNode("FormToFront") IsNot Nothing Then FormToFront = (nodeHeader.SelectSingleNode("FormToFront").InnerText = "1")
+                If nodeHeader.SelectSingleNode("FormToBack") IsNot Nothing Then
+                    FormToBack = (nodeHeader.SelectSingleNode("FormToBack").InnerText = "1")
+                    If FormToBack Then FormToFront = False
+                End If
                 If nodeHeader.SelectSingleNode("ScreenshotPath") IsNot Nothing Then
                     ScreenshotPath = nodeHeader.SelectSingleNode("ScreenshotPath").InnerText
                     ScreenshotFileType = CInt(nodeHeader.SelectSingleNode("ScreenshotFileType").InnerText)
@@ -207,6 +211,10 @@ Public Class B2SSettings
                         If nodeTable.SelectSingleNode("DualMode") IsNot Nothing Then CurrentDualMode = CInt(nodeTable.SelectSingleNode("DualMode").InnerText)
                         If nodeTable.SelectSingleNode("StartBackground") IsNot Nothing Then StartBackground = (nodeTable.SelectSingleNode("StartBackground").InnerText = "1")
                         If nodeTable.SelectSingleNode("FormToFront") IsNot Nothing Then FormToFront = (nodeTable.SelectSingleNode("FormToFront").InnerText = "1")
+                        If nodeTable.SelectSingleNode("FormToBack") IsNot Nothing Then
+                            FormToBack = (nodeTable.SelectSingleNode("FormToBack").InnerText = "1")
+                            If FormToBack Then FormToFront = False
+                        End If
 
                         Dim nodeAnimations As Xml.XmlElement = nodeTable.SelectSingleNode("Animations")
                         If nodeAnimations IsNot Nothing Then
@@ -277,9 +285,10 @@ Public Class B2SSettings
 
                 ' Only save the StartBackground setting on table level if different from GlobalStartBackground or non existent
                 If (Not GlobalStartBackground.HasValue) Or (GlobalStartBackground Xor StartBackground) Then
-                AddNode(XML, nodeTable, "StartBackground", If(StartBackground, "1", "0"))
+                    AddNode(XML, nodeTable, "StartBackground", If(StartBackground, "1", "0"))
                 End If
                 AddNode(XML, nodeTable, "FormToFront", If(FormToFront, "1", "0"))
+                AddNode(XML, nodeTable, "FormToBack", If(FormToBack, "1", "0"))
 
                 If b2sanimation IsNot Nothing Then
                     Dim nodeAnimations As Xml.XmlElement = AddHeader(XML, nodeTable, "Animations")
@@ -341,6 +350,8 @@ Public Class B2SSettings
         AnimationSlowDowns.Clear()
         AllAnimationSlowDown = 1
         CurrentDualMode = eDualMode.NotSet
+        FormToFront = True
+        FormToBack = False
     End Sub
 
     Private Shared Function AddHeader(XML As Xml.XmlDocument, parentnode As Xml.XmlNode, nodename As String) As Xml.XmlNode

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Controls/B2SLEDBox.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Controls/B2SLEDBox.vb
@@ -79,6 +79,7 @@ Public Class B2SLEDBox
 
         ' show control
         Me.Visible = True
+        Me.BringToFront()
 
     End Sub
 

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Controls/B2SPictureBox.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Controls/B2SPictureBox.vb
@@ -50,6 +50,7 @@ Public Class B2SPictureBox
 
         ' do not show the control
         MyBase.Visible = False
+        Me.BringToFront()
     End Sub
 
     Public Property PictureBoxType() As ePictureBoxType = ePictureBoxType.StandardImage

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Controls/B2SReelBox.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Controls/B2SReelBox.vb
@@ -87,6 +87,7 @@ Public Class B2SReelBox
         Me.SetStyle(ControlStyles.AllPaintingInWmPaint Or ControlStyles.UserPaint Or ControlStyles.DoubleBuffer, True)
         'Me.SetStyle(ControlStyles.SupportsTransparentBackColor, True)
         Me.DoubleBuffered = True
+        Me.BringToFront()
 
         ' back color
         'Me.BackColor = Color.Transparent

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Forms/Background.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Forms/Background.vb
@@ -2,7 +2,26 @@
 Imports System.Windows.Forms
 
 Public Class Background
+    Private Const WS_EX_NOACTIVATE As Integer = &H8000000L
 
+#Region " Properties "
+
+    ''' <summary>
+    ''' This member overrides <see cref="System.Windows.Forms.Form.CreateParams">Form.CreateParams</see>.
+    ''' </summary>
+    Protected Overrides ReadOnly Property CreateParams() As CreateParams
+        Get
+            Dim value As CreateParams = MyBase.CreateParams
+
+            'Don't allow the window to be activated.
+            If B2SSettings.FormToBack Then
+                value.ExStyle = value.ExStyle Or WS_EX_NOACTIVATE
+            End If
+            Return value
+        End Get
+    End Property
+
+#End Region 'Properties
 #Region "constructor"
 
     Public Sub New()

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formBackglass.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formBackglass.vb
@@ -4,7 +4,7 @@ Imports System.Windows.Forms
 Imports Microsoft.Win32
 
 Public Class formBackglass
-
+    Inherits System.Windows.Forms.Form
     Private Declare Function SetForegroundWindow Lib "user32.dll" (ByVal hwnd As IntPtr) As Integer
     Private Declare Function IsWindow Lib "user32.dll" (ByVal hwnd As IntPtr) As Boolean
 
@@ -30,8 +30,26 @@ Public Class formBackglass
     Private rotateSteps As Integer = 0
     Private rotateAngle As Single = 0
     Private rotateTimerInterval As Integer = 0
+    Private Const WS_EX_NOACTIVATE As Integer = &H8000000L
 
+#Region " Properties "
 
+    ''' <summary>
+    ''' This member overrides <see cref="System.Windows.Forms.Form.CreateParams">Form.CreateParams</see>.
+    ''' </summary>
+    Protected Overrides ReadOnly Property CreateParams() As CreateParams
+        Get
+            Dim value As CreateParams = MyBase.CreateParams
+
+            'Don't allow the window to be activated.
+            If B2SSettings.FormToBack Then
+                value.ExStyle = value.ExStyle Or WS_EX_NOACTIVATE
+            End If
+            Return value
+        End Get
+    End Property
+
+#End Region 'Properties
 #Region "constructor and closing"
 
     Public Sub New()

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formDMD.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formDMD.vb
@@ -2,6 +2,26 @@
 Imports System.Windows.Forms
 
 Public Class formDMD
+    Private Const WS_EX_NOACTIVATE As Integer = &H8000000L
+
+#Region " Properties "
+
+    ''' <summary>
+    ''' This member overrides <see cref="System.Windows.Forms.Form.CreateParams">Form.CreateParams</see>.
+    ''' </summary>
+    Protected Overrides ReadOnly Property CreateParams() As CreateParams
+        Get
+            Dim value As CreateParams = MyBase.CreateParams
+
+            'Don't allow the window to be activated.
+            If B2SSettings.FormToBack Then
+                value.ExStyle = value.ExStyle Or WS_EX_NOACTIVATE
+            End If
+            Return value
+        End Get
+    End Property
+
+#End Region 'Properties
 
 #Region "constructor"
 

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formSettings.Designer.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formSettings.Designer.vb
@@ -31,7 +31,9 @@ Partial Class formSettings
         Me.chkActivatePlugins = New System.Windows.Forms.CheckBox()
         Me.btnPluginSettings = New System.Windows.Forms.Button()
         Me.grpStartMode = New System.Windows.Forms.GroupBox()
-        Me.chkFormFront = New System.Windows.Forms.CheckBox()
+        Me.lblFormFront = New System.Windows.Forms.Label()
+        Me.chkDisableFuzzyMatching = New System.Windows.Forms.CheckBox()
+        Me.cmbFormFront = New System.Windows.Forms.ComboBox()
         Me.chkSmall = New System.Windows.Forms.CheckBox()
         Me.lblDefaultStartMode = New System.Windows.Forms.Label()
         Me.chkStartAsEXE = New System.Windows.Forms.CheckBox()
@@ -49,7 +51,7 @@ Partial Class formSettings
         Me.cmbAnimations = New System.Windows.Forms.ComboBox()
         Me.lblVersion = New System.Windows.Forms.Label()
         Me.grpScreenshot = New System.Windows.Forms.GroupBox()
-        Me.Label1 = New System.Windows.Forms.Label()
+        Me.lblFileType = New System.Windows.Forms.Label()
         Me.cmbScreenshotType = New System.Windows.Forms.ComboBox()
         Me.btnScreenshotPath = New System.Windows.Forms.Button()
         Me.btnCloseSettings = New System.Windows.Forms.Button()
@@ -80,7 +82,6 @@ Partial Class formSettings
         Me.numGISkipFrames = New System.Windows.Forms.NumericUpDown()
         Me.lblGIBlackTurns = New System.Windows.Forms.Label()
         Me.btnDonate = New System.Windows.Forms.Button()
-        Me.chkDisableFuzzyMatching = New System.Windows.Forms.CheckBox()
         Me.PanelSettings.SuspendLayout()
         Me.grpPlugins.SuspendLayout()
         Me.grpStartMode.SuspendLayout()
@@ -167,8 +168,9 @@ Partial Class formSettings
         '
         'grpStartMode
         '
+        Me.grpStartMode.Controls.Add(Me.lblFormFront)
         Me.grpStartMode.Controls.Add(Me.chkDisableFuzzyMatching)
-        Me.grpStartMode.Controls.Add(Me.chkFormFront)
+        Me.grpStartMode.Controls.Add(Me.cmbFormFront)
         Me.grpStartMode.Controls.Add(Me.chkSmall)
         Me.grpStartMode.Controls.Add(Me.lblDefaultStartMode)
         Me.grpStartMode.Controls.Add(Me.chkStartAsEXE)
@@ -180,15 +182,34 @@ Partial Class formSettings
         Me.grpStartMode.TabStop = False
         Me.grpStartMode.Text = "Backglass start mode"
         '
-        'chkFormFront
+        'lblFormFront
         '
-        Me.chkFormFront.AutoSize = True
-        Me.chkFormFront.Location = New System.Drawing.Point(80, 50)
-        Me.chkFormFront.Name = "chkFormFront"
-        Me.chkFormFront.Size = New System.Drawing.Size(127, 17)
-        Me.chkFormFront.TabIndex = 39
-        Me.chkFormFront.Text = "Bring BG Form to Top"
-        Me.chkFormFront.UseVisualStyleBackColor = True
+        Me.lblFormFront.AutoSize = True
+        Me.lblFormFront.Location = New System.Drawing.Point(12, 49)
+        Me.lblFormFront.Name = "lblFormFront"
+        Me.lblFormFront.Size = New System.Drawing.Size(47, 13)
+        Me.lblFormFront.TabIndex = 41
+        Me.lblFormFront.Text = "Bring BG"
+        '
+        'chkDisableFuzzyMatching
+        '
+        Me.chkDisableFuzzyMatching.AutoSize = True
+        Me.chkDisableFuzzyMatching.Location = New System.Drawing.Point(221, 50)
+        Me.chkDisableFuzzyMatching.Name = "chkDisableFuzzyMatching"
+        Me.chkDisableFuzzyMatching.Size = New System.Drawing.Size(159, 17)
+        Me.chkDisableFuzzyMatching.TabIndex = 40
+        Me.chkDisableFuzzyMatching.Text = "Exact .directb2s match only"
+        Me.chkDisableFuzzyMatching.UseVisualStyleBackColor = True
+        '
+        'cmbFormFront
+        '
+        Me.cmbFormFront.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.cmbFormFront.FormattingEnabled = True
+        Me.cmbFormFront.Items.AddRange(New Object() {"Form to Back", "Standard", "Form to Top"})
+        Me.cmbFormFront.Location = New System.Drawing.Point(65, 46)
+        Me.cmbFormFront.Name = "cmbFormFront"
+        Me.cmbFormFront.Size = New System.Drawing.Size(127, 21)
+        Me.cmbFormFront.TabIndex = 27
         '
         'chkSmall
         '
@@ -353,12 +374,12 @@ Partial Class formSettings
         Me.lblVersion.Location = New System.Drawing.Point(54, 30)
         Me.lblVersion.Name = "lblVersion"
         Me.lblVersion.Size = New System.Drawing.Size(265, 13)
-        Me.lblVersion.TabIndex = 27
+        Me.lblVersion.TabIndex = 38
         Me.lblVersion.Text = "Server version {0}, Backglass file version {1}"
         '
         'grpScreenshot
         '
-        Me.grpScreenshot.Controls.Add(Me.Label1)
+        Me.grpScreenshot.Controls.Add(Me.lblFileType)
         Me.grpScreenshot.Controls.Add(Me.cmbScreenshotType)
         Me.grpScreenshot.Controls.Add(Me.btnScreenshotPath)
         Me.grpScreenshot.Location = New System.Drawing.Point(12, 453)
@@ -368,15 +389,15 @@ Partial Class formSettings
         Me.grpScreenshot.TabStop = False
         Me.grpScreenshot.Text = "Screenshot"
         '
-        'Label1
+        'lblFileType
         '
-        Me.Label1.AutoSize = True
-        Me.Label1.Location = New System.Drawing.Point(268, 19)
-        Me.Label1.Name = "Label1"
-        Me.Label1.Size = New System.Drawing.Size(83, 13)
-        Me.Label1.TabIndex = 27
-        Me.Label1.Text = "Image file type:"
-        Me.Label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight
+        Me.lblFileType.AutoSize = True
+        Me.lblFileType.Location = New System.Drawing.Point(268, 19)
+        Me.lblFileType.Name = "lblFileType"
+        Me.lblFileType.Size = New System.Drawing.Size(83, 13)
+        Me.lblFileType.TabIndex = 0
+        Me.lblFileType.Text = "Image file type:"
+        Me.lblFileType.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         '
         'cmbScreenshotType
         '
@@ -691,16 +712,6 @@ Partial Class formSettings
         Me.btnDonate.UseVisualStyleBackColor = True
         Me.btnDonate.Visible = False
         '
-        'chkDisableFuzzyMatching
-        '
-        Me.chkDisableFuzzyMatching.AutoSize = True
-        Me.chkDisableFuzzyMatching.Location = New System.Drawing.Point(221, 50)
-        Me.chkDisableFuzzyMatching.Name = "chkDisableFuzzyMatching"
-        Me.chkDisableFuzzyMatching.Size = New System.Drawing.Size(159, 17)
-        Me.chkDisableFuzzyMatching.TabIndex = 40
-        Me.chkDisableFuzzyMatching.Text = "Exact .directb2s match only"
-        Me.chkDisableFuzzyMatching.UseVisualStyleBackColor = True
-        '
         'formSettings
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -747,7 +758,7 @@ Partial Class formSettings
     Friend WithEvents cmbAnimations As System.Windows.Forms.ComboBox
     Friend WithEvents lblVersion As System.Windows.Forms.Label
     Friend WithEvents grpScreenshot As System.Windows.Forms.GroupBox
-    Friend WithEvents Label1 As System.Windows.Forms.Label
+    Friend WithEvents lblFileType As System.Windows.Forms.Label
     Friend WithEvents cmbScreenshotType As System.Windows.Forms.ComboBox
     Friend WithEvents btnScreenshotPath As System.Windows.Forms.Button
     Friend WithEvents btnCloseSettings As System.Windows.Forms.Button
@@ -795,6 +806,7 @@ Partial Class formSettings
     Friend WithEvents chkActivatePlugins As System.Windows.Forms.CheckBox
     Friend WithEvents btnPluginSettings As System.Windows.Forms.Button
     Friend WithEvents chkSmall As Windows.Forms.CheckBox
-    Friend WithEvents chkFormFront As Windows.Forms.CheckBox
+    Friend WithEvents lblFormFront As Windows.Forms.Label
+    Friend WithEvents cmbFormFront As Windows.Forms.ComboBox
     Friend WithEvents chkDisableFuzzyMatching As Windows.Forms.CheckBox
 End Class

--- a/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formSettings.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/Forms/formSettings.vb
@@ -83,7 +83,7 @@ Public Class formSettings
             radioDream7LED.Enabled = False
         End If
         chkBulbs.Checked = B2SSettings.IsGlowBulbOn
-        chkFormFront.Checked = B2SSettings.FormToFront
+        cmbFormFront.SelectedIndex = If(B2SSettings.FormToBack, 0, If(B2SSettings.FormToFront, 2, 1))
         chkDisableFuzzyMatching.Checked = B2SSettings.DisableFuzzyMatching
 
         cmbGlowing.SelectedIndex = If(B2SSettings.GlowIndex <> -1, B2SSettings.GlowIndex, cmbGlowing.Items.Count - 1)
@@ -455,8 +455,15 @@ Public Class formSettings
         Return ret
     End Function
 
-    Private Sub CheckBox1_CheckedChanged(sender As Object, e As EventArgs) Handles chkFormFront.CheckedChanged
-        B2SSettings.FormToFront = chkFormFront.Checked
+    Private Sub cmbFormFront_SelectedIndexChanged(sender As Object, e As EventArgs) Handles cmbFormFront.SelectedIndexChanged
+        B2SSettings.FormToBack = False
+        B2SSettings.FormToFront = False
+
+        If cmbFormFront.SelectedIndex = 0 Then
+            B2SSettings.FormToBack = True
+        ElseIf cmbFormFront.SelectedIndex = 2 Then
+            B2SSettings.FormToFront = True
+        End If
     End Sub
 
     Private Sub chkDisableFuzzyMatching_CheckedChanged(sender As Object, e As EventArgs) Handles chkDisableFuzzyMatching.CheckedChanged

--- a/b2sbackglassserverexe/b2sbackglassserverexe/My Project/AssemblyInfo.vb
+++ b/b2sbackglassserverexe/b2sbackglassserverexe/My Project/AssemblyInfo.vb
@@ -31,6 +31,6 @@ Imports System.Runtime.InteropServices
 ' übernehmen, indem Sie "*" eingeben:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.3.1.1")>
-<Assembly: AssemblyFileVersion("1.3.1.1")>
-<Assembly: AssemblyInformationalVersion("1.3.1.1")>
+<Assembly: AssemblyVersion("1.3.1.2")>
+<Assembly: AssemblyFileVersion("1.3.1.2")>
+<Assembly: AssemblyInformationalVersion("1.3.1.2")>

--- a/b2sbackglassserverregisterapp/b2sbackglassserverregisterapp/My Project/AssemblyInfo.vb
+++ b/b2sbackglassserverregisterapp/b2sbackglassserverregisterapp/My Project/AssemblyInfo.vb
@@ -31,6 +31,6 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.3.1.1")> 
-<Assembly: AssemblyFileVersion("1.3.1.1")> 
-<Assembly: AssemblyInformationalVersion("1.3.1.1")> 
+<Assembly: AssemblyVersion("1.3.1.2")> 
+<Assembly: AssemblyFileVersion("1.3.1.2")> 
+<Assembly: AssemblyInformationalVersion("1.3.1.2")> 


### PR DESCRIPTION
there is now three states available to control the backglass by using two settings in the xml file (FormToBack and FormToFront):
In the GUI there are three states:
  1. "Standard" setting (both FormToBack and FormToFront turned off) is now as it was in 1.3.0.6. -> formDMD isn't controlled by the FormToFront/Back setting
  2. FormToFront sets the flag Form.TopMost = True -> cannot get any other window on top
  3. FormToBack, forces the forms back and ignores any try to get them come forward -> Windows stay in back. The B2S Server is not available in the taskbar anymore.
-