### PR TITLE
ci: update workflows to fix deprecation warnings

### DIFF
--- a/.github/workflows/b2s-backglass.yml
+++ b/.github/workflows/b2s-backglass.yml
@@ -52,7 +52,7 @@ jobs:
           VERSION=$(grep -Eo "AssemblyVersion\(.*\)" "${ASSEMBLY_INFO}" | grep -Eo "[0-9\.]+" | tail -1)
           TAG="${VERSION}-${SHA7}"
           perl -i -pe"s/AssemblyInformationalVersion\(\".*\"\)/AssemblyInformationalVersion\(\"${TAG}\"\)/g" "${ASSEMBLY_INFO}"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - uses: microsoft/setup-msbuild@v1.1
       - name: Build B2SServerPluginInterface
         run: |
@@ -123,7 +123,7 @@ jobs:
           VERSION=$(grep -Eo "AssemblyVersion\(.*\)" "${ASSEMBLY_INFO}" | grep -Eo "[0-9\.]+" | tail -1)
           TAG="${VERSION}-${SHA7}"
           perl -i -pe"s/AssemblyInformationalVersion\(\".*\"\)/AssemblyInformationalVersion\(\"${TAG}\"\)/g" "${ASSEMBLY_INFO}"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - uses: microsoft/setup-msbuild@v1.1
       - name: Build
         run: |
@@ -152,7 +152,7 @@ jobs:
 
   build-betterled:
     if: ${{ false }}  # disable for now
-    name: Build BetterLed-${{ matrix.config }}-win-${{ matrix.platform }}
+    name: Build BetterLed # -${{ matrix.config }}-win-${{ matrix.platform }}
     runs-on: windows-2019
     strategy:
       fail-fast: false
@@ -180,7 +180,7 @@ jobs:
           VERSION=$(grep -Eo "AssemblyVersion\(.*\)" "${ASSEMBLY_INFO}" | grep -Eo "[0-9\.]+" | tail -1)
           TAG="${VERSION}-${SHA7}"
           perl -i -pe"s/AssemblyInformationalVersion\(\".*\"\)/AssemblyInformationalVersion\(\"${TAG}\"\)/g" "${ASSEMBLY_INFO}"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - uses: microsoft/setup-msbuild@v1.1
       - name: Build
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,8 +20,8 @@ jobs:
         run: |
            SHA=$(if [[ "${{ github.event.inputs.sha }}" ]]; then echo "${{ github.event.inputs.sha }}"; else echo "${GITHUB_SHA}"; fi)
            SHA7="${SHA::7}"
-           echo "::set-output name=sha::${SHA}"
-           echo "::set-output name=sha7::${SHA7}"
+           echo "sha=${SHA}" >> $GITHUB_OUTPUT
+           echo "sha7=${SHA7}" >> $GITHUB_OUTPUT
 
   prerelease:
     runs-on: ubuntu-latest
@@ -41,18 +41,11 @@ jobs:
            done
            rm *.json
       - id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: "b2s-backglass-${{ needs.version.outputs.sha7 }}" 
-          release_name: "b2s-backglass-${{ needs.version.outputs.sha7 }}"
           prerelease: true
-          commitish: ${{ needs.version.outputs.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - id: upload_release_assets
-        uses: dwenegar/upload-release-assets@v1
-        with:
-          release_id: ${{ steps.create_release.outputs.id }}
-          assets_path: .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: "b2s-backglass-${{ needs.version.outputs.sha7 }}"
+          tag: "b2s-backglass-${{ needs.version.outputs.sha7 }}" 
+          commit: ${{ needs.version.outputs.sha }}
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "*"


### PR DESCRIPTION
This PR is to fix the deprecation warnings that are output during CI builds.

Also, the `prerelease` workflow has been modified as `create-release` is no longer maintained by GitHub. We now use a recommended alternative `ncipollo/release-action@v1`. 