### PR TITLE
Fix B2S not detecting VPX window

### DIFF
--- a/b2sbackglassserver/b2sbackglassserver/Classes/Processes.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Classes/Processes.vb
@@ -115,7 +115,7 @@ Public Class Processes
     End Property
 
     Private Function EnumWinProc(ByVal hwnd As IntPtr, ByVal lParam As Int32) As Boolean
-        If IsWindowVisible(hwnd) AndAlso GetParent(hwnd) = IntPtr.Zero AndAlso GetWindowLong(hwnd, GWL_HWNDPARENT) = 0 Then
+        If GetParent(hwnd) = IntPtr.Zero AndAlso GetWindowLong(hwnd, GWL_HWNDPARENT) = 0 Then
             Dim str As String = String.Empty.PadLeft(GetWindowTextLength(hwnd) + 1)
             GetWindowText(hwnd, str, str.Length)
             If Not String.IsNullOrEmpty(str.Substring(0, str.Length - 1)) Then windowlist.Add(New ProcInfo(str.Substring(0, str.Length - 1), hwnd))
@@ -128,3 +128,4 @@ Public Class Processes
     End Sub
 
 End Class
+


### PR DESCRIPTION
see https://github.com/vpinball/vpinball/pull/2529

B2S expects VPX window to be visible which is something that can not be guaranteed (it is hidden at some point, earlier in latest build, but it has laways been a race between VPX and B2S).