### PR TITLE
Make the wrapped controller ProgID configurable (default VPinMAME)

### DIFF
--- a/b2sbackglassserver/b2sbackglassserver/Classes/B2SData.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Classes/B2SData.vb
@@ -22,10 +22,26 @@ Public Class B2SData
 #If B2S = "DLL" Then
     Private Shared _vpinmame As Object = Nothing
     Public Shared VPMHasTimeFence As Boolean = False
+    ' COM ProgID of the controller B2S wraps. Defaults to VPinMAME so existing
+    ' tables are unaffected; a table may override it (e.g. "VPROC.Controller")
+    ' via Server.ControllerProgID to drive an alternative controller that
+    ' implements the same VPinMAME COM interface (GameName, Run,
+    ' ChangedLamps/Solenoids/GIStrings, ...).
+    Private Shared _controllerProgID As String = "VPinMAME.Controller"
+    Public Shared Property ControllerProgID() As String
+        Get
+            Return _controllerProgID
+        End Get
+        Set(ByVal value As String)
+            If Not String.IsNullOrEmpty(value) Then
+                _controllerProgID = value
+            End If
+        End Set
+    End Property
     Public Shared ReadOnly Property VPinMAME() As Object
         Get
             If _vpinmame Is Nothing OrElse IsStopped Then
-                _vpinmame = CreateObject("VPinMAME.Controller")
+                _vpinmame = CreateObject(_controllerProgID)
                 VPMHasTimeFence = _vpinmame.GetType.GetProperty("TimeFence") IsNot Nothing
                 If IsStopped Then
                     _vpinmame.GameName = stoppedGameName

--- a/b2sbackglassserver/b2sbackglassserver/Server.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Server.vb
@@ -92,6 +92,15 @@ Public Class Server
 
     Public Sub New()
 
+        ' Reset the wrapped-controller ProgID to the VPinMAME default for each
+        ' fresh table. ControllerProgID is process-wide (Shared), so without
+        ' this a table that selected an alternative controller could leave it
+        ' set for the next table launched in the same VPX process. This runs
+        ' per CreateObject("B2S.Server") (i.e. per table), but NOT on the
+        ' in-session soft restart (which reuses the same Server instance), so a
+        ' table's own override survives a controller stop/restart.
+        B2SData.ControllerProgID = "VPinMAME.Controller"
+
         ' maybe create the base registry key
         If Registry.CurrentUser.OpenSubKey("Software\B2S") Is Nothing Then Registry.CurrentUser.CreateSubKey("Software\B2S")
         If Registry.CurrentUser.OpenSubKey("Software\B2S\VPinMAME") Is Nothing Then Registry.CurrentUser.CreateSubKey("Software\B2S\VPinMAME")
@@ -284,6 +293,21 @@ Public Class Server
         Get
             Return System.Reflection.Assembly.GetExecutingAssembly().Location
         End Get
+    End Property
+
+    ' COM ProgID of the controller B2S wraps for the pull path
+    ' (ChangedLamps/Solenoids/GIStrings). Defaults to "VPinMAME.Controller";
+    ' a table may set it BEFORE GameName/Run to drive an alternative
+    ' controller that implements the same COM interface, e.g.:
+    '   B2SController.ControllerProgID = "VPROC.Controller"
+    ' Existing tables that never set it are unaffected.
+    Public Property ControllerProgID() As String
+        Get
+            Return B2SData.ControllerProgID
+        End Get
+        Set(ByVal value As String)
+            B2SData.ControllerProgID = value
+        End Set
     End Property
 
     Public Property GameName() As String


### PR DESCRIPTION
## What

Adds a `ControllerProgID` property to `B2S.Server` (backed by `B2SData`), defaulting to `"VPinMAME.Controller"`. A table can set it **before** `GameName`/`Run` to make B2S's pull path wrap a different controller that implements the same COM interface:

```vbscript
B2SController.ControllerProgID = "VPROC.Controller"
```

## Why

B2S's automatic backglass mapping creates its controller with a hardcoded `CreateObject("VPinMAME.Controller")` (`B2SData.vb`), then polls `ChangedLamps` / `ChangedSolenoids` / `ChangedGIStrings` / `ChangedLEDs` (`Server.vb`). Because the ProgID is fixed, only VPinMAME can drive `.directb2s` backglasses automatically. Other controllers that expose the identical COM interface — e.g. P-ROC game bridges — can't use the auto-mapping path today; authors have to push every element by hand via `B2SSetData`.

Making just the ProgID configurable lets those controllers reuse the existing, well-tested pull path with no other changes.

## Behavior / compatibility

- **Default unchanged** (`VPinMAME.Controller`) — tables that never set the property behave exactly as before.
- `Server.New()` resets the ProgID to the default on each `CreateObject("B2S.Server")` (i.e. per table), so a table that selects an alternative controller can't leak that choice onto the next table launched in the same VPX process. The in-session soft restart reuses the same `Server` instance, so a table's own override survives a controller stop/restart.
- No change to the `B2SSetData` push path.
- 2 files, +41/-1.
