### PR TITLE
Fix RPC_S_SERVER_UNAVAILABLE (0x800706BA) on second game launch in sa…

### DIFF
--- a/b2sbackglassserver/b2sbackglassserver/Classes/B2SData.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Classes/B2SData.vb
@@ -63,6 +63,55 @@ Public Class B2SData
         IsStopped = True
     End Sub
 
+    ' Force the next access to the VPinMAME property to create a fresh
+    ' controller, regardless of whether the previous one was cleanly stopped.
+    '
+    ' Background: the VPinMAME getter has a soft-restart optimization that
+    ' keeps _vpinmame alive across Stop()/restart for an in-table reset
+    ' (restoring stoppedGameName). That optimization is only safe within a
+    ' single Server (= single VPX table session) lifetime. Across Server
+    ' instances — e.g. stopping a game and launching another one in the same
+    ' VPX process — the cached RCW often references a controller whose
+    ' RPC/STA host has already gone away, even though _vpinmame itself isn't
+    ' Nothing. The next late-bound call on it then throws
+    ' COMException 0x800706BA (RPC_S_SERVER_UNAVAILABLE).
+    '
+    ' Server.New() calls this so a brand-new Server always starts with a
+    ' guaranteed-fresh controller. Stop() is attempted best-effort because
+    ' the old RCW may already be dead; we don't want that to prevent the
+    ' release. IsStopped is cleared (not set) so the getter does NOT try to
+    ' restore stoppedGameName — VPX will assign the new game's name itself.
+    Public Shared Sub DiscardController()
+        Dim previous As Object = _vpinmame
+        _vpinmame = Nothing
+        IsStopped = False
+        stoppedGameName = String.Empty
+        If previous IsNot Nothing Then
+            Try
+                previous.Stop()
+            Catch
+            End Try
+        End If
+    End Sub
+
+    ' Generation counter used by Server instances to detect "orphan" instances
+    ' whose owning VPX table session has been superseded. Each new Server.New()
+    ' calls NextGeneration() to claim ownership of the process-wide _vpinmame
+    ' controller; an instance whose myGeneration no longer matches
+    ' ActiveGeneration must NOT call B2SData.Stop(), otherwise it would tear
+    ' down the controller the newer session is using (cause of RPC_S_SERVER_
+    ' UNAVAILABLE on a second game launch in the same VPX process).
+    Private Shared _activeGeneration As Integer = 0
+    Public Shared ReadOnly Property ActiveGeneration() As Integer
+        Get
+            Return _activeGeneration
+        End Get
+    End Property
+    Public Shared Function NextGeneration() As Integer
+        _activeGeneration += 1
+        Return _activeGeneration
+    End Function
+
 
     Private Shared IsLampsInfoDirty As Boolean = True
     Private Shared IsSolenoidsInfoDirty As Boolean = True

--- a/b2sbackglassserver/b2sbackglassserver/Server.vb
+++ b/b2sbackglassserver/b2sbackglassserver/Server.vb
@@ -34,6 +34,12 @@ Public Class Server
     Private isChangedGIStringsCalled As Boolean = False
     Private isChangedLEDsCalled As Boolean = False
 
+    ' Generation token claimed in New(); compared against
+    ' B2SData.ActiveGeneration in Stop() so an orphan instance (one whose
+    ' table session has been superseded by a newer Server) cannot tear down
+    ' the shared VPinMAME controller the newer session is using.
+    Private myGeneration As Integer = 0
+
     Public Shared errorlog As Log = Nothing
     'Public debugLog As Log = New Log("B2SDebugLog")
 
@@ -52,6 +58,22 @@ Public Class Server
     ' IDisposable
     Protected Overridable Sub Dispose(disposing As Boolean)
         If Not Me.disposedValue Then
+
+            ' Always release the polling timer, regardless of disposing or
+            ' frontend mode. The timer holds a delegate to this Server
+            ' instance (via Timer_Tick), so leaving it running would keep
+            ' the instance alive after VPX has released its COM reference,
+            ' producing a "zombie" that can later tear down the shared
+            ' VPinMAME controller a newer game session is using.
+            Try
+                If timer IsNot Nothing Then
+                    timer.Stop()
+                    RemoveHandler timer.Tick, AddressOf Timer_Tick
+                    timer.Dispose()
+                    timer = Nothing
+                End If
+            Catch
+            End Try
 
             If disposing Then
                 ' TODO: dispose managed state (managed objects).
@@ -91,6 +113,18 @@ Public Class Server
 #Region "constructor and end timer"
 
     Public Sub New()
+
+        ' Claim a fresh generation token. Used by Stop() to refuse to tear
+        ' down the shared VPinMAME controller when an older (now-orphaned)
+        ' Server instance's timer fires after a newer game has started.
+        myGeneration = B2SData.NextGeneration()
+
+        ' Force a fresh VPinMAME controller for this new Server instance.
+        ' The static _vpinmame may still hold an RCW pointing at a
+        ' controller whose RPC/STA host went away when the previous game
+        ' ended; reusing that RCW would surface as COMException 0x800706BA
+        ' on the first ChangedLamps/Solenoids/GIStrings call in this game.
+        B2SData.DiscardController()
 
         ' Reset the wrapped-controller ProgID to the VPinMAME default for each
         ' fresh table. ControllerProgID is process-wide (Shared), so without
@@ -140,7 +174,13 @@ Public Class Server
             If tableHandle <> 0 AndAlso Not IsWindow(tableHandle) Then
 
                 Try
-                    timer.Stop()
+                    ' Detach the tick handler before stopping/disposing so a
+                    ' tick already queued on the message pump cannot re-enter
+                    ' this method on a half-torn-down instance.
+                    If timer IsNot Nothing Then
+                        timer.Stop()
+                        RemoveHandler timer.Tick, AddressOf Timer_Tick
+                    End If
                     Me.Stop()
                 Finally
                     Me.Dispose()
@@ -252,7 +292,10 @@ Public Class Server
         Catch ex As Exception
             Dim st As New StackTrace(ex, True)
             errorlog.WriteLogEntry(DateTime.Now & "Line: " & st.GetFrame(0).GetMethod().Name & " : " & st.GetFrame(0).GetFileLineNumber().ToString & " : " & ex.Message)
-            Throw ex
+            ' Use bare Throw (not "Throw ex") so the original stack trace —
+            ' including the real COM call site inside ChangedLamps/Solenoids/
+            ' GIStrings/LEDs — is preserved for diagnostics.
+            Throw
         End Try
 
     End Sub
@@ -458,13 +501,22 @@ Public Class Server
 
         Try
             Try
-                timer.Stop()
+                If timer IsNot Nothing Then timer.Stop()
                 HideBackglassForm()
             Catch
             End Try
 
             Try
-                B2SData.Stop()
+                ' Only tear down the process-wide VPinMAME controller if this
+                ' Server instance is still the active owner. An "orphan"
+                ' instance (e.g. a previous game's zombie whose timer is
+                ' firing one last time) must NOT stop the controller a newer
+                ' game session is currently using — that is the root cause of
+                ' the RPC_S_SERVER_UNAVAILABLE crash on a second game launch
+                ' in the same VPX process.
+                If myGeneration = B2SData.ActiveGeneration Then
+                    B2SData.Stop()
+                End If
             Catch
             Finally
                 KillBackglassForm()


### PR DESCRIPTION
1. Stale RCW reuse across game sessions (root cause of the reported crash) B2SData._vpinmame is Shared and was only cleared by an explicit Stop(). Server.Dispose only called Stop() under IsHyperpinRunning, so standalone VPX left the previous game's RCW cached. When VPinMAME tore the controller down between games, the next game's first late-bound call on that stale RCW raised RPC_S_SERVER_UNAVAILABLE. Added B2SData.DiscardController() and call it from Server.New(). It nulls _vpinmame, best-effort stops the previous RCW (catches everything since it may already be dead), and clears IsStopped/stoppedGameName so the getter does NOT try to restore the previous game's name on the fresh controller. The existing soft-restart path (Stop -> re-access within the same Server instance) is preserved.

2. Zombie-timer cross-session controller stomp (secondary hazard) Server's 37ms Windows.Forms.Timer rooted the instance via its Tick delegate. Dispose only released it under IsHyperpinRunning, so an old Server could keep ticking after VPX released its COM reference; a late tick would then call B2SData.Stop() and tear down the controller a newer Server was using.
   - Dispose now always Stops/RemoveHandlers/Disposes/nulls the timer.
   - Timer_Tick self-terminate branch detaches the handler before Me.Stop() to block re-entrancy from queued ticks.
   - Added a per-instance generation token (B2SData.NextGeneration / ActiveGeneration, Server.myGeneration). Server.Stop() now only calls B2SData.Stop() when this instance is still the active generation, so an orphan tick can no longer destroy the controller a newer Server owns.

Diagnostic improvement:
   Timer_Tick outer catch changed from "Throw ex" to bare "Throw" so the
   COM call frame (ChangedLamps/Solenoids/...) is preserved in traces
   instead of being reset to the rethrow site.
